### PR TITLE
update v2 contract-events, handle nil rule on buffer before inputs

### DIFF
--- a/cmd/fraxlend-screener/thirdweb_test.go
+++ b/cmd/fraxlend-screener/thirdweb_test.go
@@ -77,10 +77,13 @@ func TestFraxlendContractEvents_BorrowAsset(t *testing.T) {
 		t.Errorf("error: %v \n", err)
 	}
 	contract, err := sdk.GetContractFromAbi(FXS_FRAX_POOL, FRAXLEND_PAIR_ABI)
-	//filters := map[string]interface{}{
-	//	"_borrower": common.HexToAddress("0xd1F2739ad714045BE6146915275D0a2B822Ec1CC"),
-	//}
-	events, _ := contract.Events.GetEvents(context.Background(), "BorrowAsset", thirdweb.EventQueryOptions{})
+	filters := map[string]interface{}{
+		"_borrower": common.HexToAddress("0xd1F2739ad714045BE6146915275D0a2B822Ec1CC"),
+	}
+	queryOptions := thirdweb.EventQueryOptions{
+		Filters: filters,
+	}
+	events, _ := contract.Events.GetEvents(context.Background(), "BorrowAsset", queryOptions)
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/thirdweb-dev/go-sdk v1.3.3 // indirect
-	github.com/thirdweb-dev/go-sdk/v2 v2.0.0-beta-0.0.20221116010258-c2277b7fd7b5 // indirect
+	github.com/thirdweb-dev/go-sdk/v2 v2.0.0-beta-0.0.20221116151454-a5ac5d6142b2 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.5.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,8 @@ github.com/thirdweb-dev/go-sdk v1.3.3 h1:Ra1KRET+Pnbcfl+RLAIsQAtPsYLWVUEFe1Ouuqo
 github.com/thirdweb-dev/go-sdk v1.3.3/go.mod h1:p7fAoGskJuTbpCt6qIA6sIxgFbSt+du/far9+i3YKYU=
 github.com/thirdweb-dev/go-sdk/v2 v2.0.0-beta-0.0.20221116010258-c2277b7fd7b5 h1:ykWs1v0SJYND1CAbCzHMa9vPWqsENEIdrZAEoaHZORI=
 github.com/thirdweb-dev/go-sdk/v2 v2.0.0-beta-0.0.20221116010258-c2277b7fd7b5/go.mod h1:RaTf6H9WYYa+2oSjN5UxwMVfl6mwUX4xxsYIraHdN1c=
+github.com/thirdweb-dev/go-sdk/v2 v2.0.0-beta-0.0.20221116151454-a5ac5d6142b2 h1:RLaCtQm1ZLvuAV/hRY5LeMK5sNRmg7cMTozh5TSF6Uw=
+github.com/thirdweb-dev/go-sdk/v2 v2.0.0-beta-0.0.20221116151454-a5ac5d6142b2/go.mod h1:RaTf6H9WYYa+2oSjN5UxwMVfl6mwUX4xxsYIraHdN1c=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
 github.com/tklauser/go-sysconf v0.3.10 h1:IJ1AZGZRWbY8T5Vfk04D9WOA5WSejdflXxP03OUqALw=


### PR DESCRIPTION
nil rule is only necessary as a buffer before inputs

example: `Transfer` event has indexed inputs: `from` and `to`
- so if you wanted to filter `to`, you would have to pass nil first to buffer it: `[nil, to]`
- if you only wanted to filter `from`, you could just do: `[from]` or `[from, nil]`

example 2: `BorrowAsset` event on Fraxlend Pair has indexed inputs: `_borrower`, `_receiver`,
- filtering for `_receiver` would be: `[nil, receiver]`